### PR TITLE
feat: add inputBudhistYear and outputBudhistYear properties for date …

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This library extends the [PrimeNG Datepicker](https://primeng.org/datepicker) to
 
 | Angular Version        | Library Version                       | Install Command                                  |
 | ---------------------- | ------------------------------------- | ------------------------------------------------ |
-| `^21.0.0`              | `primeng-buddhist-year-datepicker@21` | `npm i primeng-buddhist-year-datepicker` |
+| `^21.0.0`              | `primeng-buddhist-year-datepicker@21` | `npm i primeng-buddhist-year-datepicker`         |
 | `^20.0.0`              | `primeng-buddhist-year-datepicker@20` | `npm i primeng-buddhist-year-datepicker@^20.0.0` |
 | `^19.0.0`              | `primeng-buddhist-year-datepicker@19` | `npm i primeng-buddhist-year-datepicker@^19.0.0` |
 | `^17.0.0` to `<19.0.0` | `primeng-buddhist-year-datepicker@17` | `npm i primeng-buddhist-year-datepicker@^17.0.0` |
@@ -26,6 +26,9 @@ To see the component in action:
 
 ```bash
 npm install
+
+ng build primeng-buddhist-datepicker
+
 ng serve
 ```
 
@@ -47,9 +50,11 @@ selector datepicker the same as primeng add only [isBudhistYear] = true or false
   template: `
     <p-date-picker
       [isBudhistYear]="true"
+      [inputBudhistYear]="false"
+      [outputBudhistYear]="true"
       dateFormat="dd/mm/yy"
       placeholder="Select a date"
-    ></<p-date-picker>
+    ></p-date-picker>
   `
 })
 export class YourComponent {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@primeuix/themes": "^2.0.2",
         "primeicons": "^7.0.0",
         "primeng": "^21.0.2",
+        "primeng-buddhist-year-datepicker": "^21.0.1",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -9688,6 +9689,24 @@
         "@angular/platform-browser": "^21.0.0",
         "@angular/router": "^21.0.0",
         "rxjs": "^6.0.0 || ^7.8.1"
+      }
+    },
+    "node_modules/primeng-buddhist-year-datepicker": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/primeng-buddhist-year-datepicker/-/primeng-buddhist-year-datepicker-21.0.1.tgz",
+      "integrity": "sha512-P1KxteUZU7PcpxugLeMlH257oqlq6j88clH50Q6WJ+u0XQvq9bKvdH0+FbSwpk6miMXcoW1O8g+IWzgDlpk+dw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^21.0.0",
+        "@angular/compiler": "^21.0.0",
+        "@angular/core": "^21.0.0",
+        "@angular/forms": "^21.0.0",
+        "@primeuix/themes": "^2.0.0",
+        "primeicons": "^7.0.0",
+        "primeng": "^21.0.0"
       }
     },
     "node_modules/primeng/node_modules/@primeuix/styled": {

--- a/projects/demo-app/src/app/app.component.html
+++ b/projects/demo-app/src/app/app.component.html
@@ -1,29 +1,42 @@
-<div style="display: flex; flex-direction: column; justify-content: center;align-items: center; width: 100vw; height: 100vh;">
-  <div style="width: 400px;  display: flex; flex-direction: column; gap: 4rem;">
-    <div style="display: flex; flex-direction: column;">
-      <label>Pick Date Budhist Year [isBudhistYear]="true"</label>
-      <p-date-picker [isBudhistYear]="true" [(ngModel)]="date"></p-date-picker>
-      <span style="font-size: small;">{{date}}</span>
-    </div>
-  
-      <div style="display: flex; flex-direction: column; ">
-      <label>Pick Date Range Budhist Year [isBudhistYear]="true"</label>
-      <p-date-picker [isBudhistYear]="true" [(ngModel)]="dateRange" selectionMode="range" (ngModelChange)="logData()"></p-date-picker>
-      <span style="font-size: small;">{{ "Date from : " + dateRange?.[0] }}</span>
-      <span style="font-size: small;">{{ "Date To : " + dateRange?.[1] }}</span>
+<div style="display: flex; flex-direction: column; justify-content: center;align-items: center; width: 100vw; min-height: 100vh; padding: 2rem;">
+  <h1 style="margin-bottom: 2rem;">Buddhist Year DatePicker Demo</h1>
+  <div style="width: 500px; display: flex; flex-direction: column; gap: 2rem;">
+    
+    <!-- Scenario 1: Display พ.ศ., Output ค.ศ. (default behavior) -->
+    <div style="display: flex; flex-direction: column; border: 1px solid #ccc; padding: 1rem; border-radius: 8px;">
+      <label style="font-weight: bold; margin-bottom: 0.5rem;">Scenario 1: Display พ.ศ., Output ค.ศ.</label>
+      <code style="font-size: 0.8rem; margin-bottom: 0.5rem;">[isBudhistYear]="true" [outputBudhistYear]="false"</code>
+      <p-date-picker [isBudhistYear]="true" [outputBudhistYear]="false" [(ngModel)]="date1"></p-date-picker>
+      <span style="font-size: small; margin-top: 0.5rem;">Output: {{date1}}</span>
+      <span style="font-size: small; color: green;">Year: {{date1?.getFullYear()}}</span>
     </div>
 
-        <div style="display: flex; flex-direction: column;">
-      <label>Pick Date Budhist Year [isBudhistYear]="false"</label>
-      <p-date-picker [isBudhistYear]="false" [(ngModel)]="date"></p-date-picker>
-      <span style="font-size: small;">{{date}}</span>
+    <!-- Scenario 2: Display พ.ศ., Output พ.ศ. -->
+    <div style="display: flex; flex-direction: column; border: 1px solid #ccc; padding: 1rem; border-radius: 8px;">
+      <label style="font-weight: bold; margin-bottom: 0.5rem;">Scenario 2: Display พ.ศ., Output พ.ศ.</label>
+      <code style="font-size: 0.8rem; margin-bottom: 0.5rem;">[isBudhistYear]="true" [outputBudhistYear]="true"</code>
+      <p-date-picker [isBudhistYear]="true" [outputBudhistYear]="true" [(ngModel)]="date2"></p-date-picker>
+      <span style="font-size: small; margin-top: 0.5rem;">Output: {{date2}}</span>
+      <span style="font-size: small; color: green;">Year: {{date2?.getFullYear()}}</span>
     </div>
-  
-      <div style="display: flex; flex-direction: column; ">
-      <label>Pick Date Range Budhist Year [isBudhistYear]="false"</label>
-      <p-date-picker [isBudhistYear]="false" [(ngModel)]="dateRange" selectionMode="range" (ngModelChange)="logData()"></p-date-picker>
-      <span style="font-size: small;">{{ "Date from : " + dateRange?.[0] }}</span>
-      <span style="font-size: small;">{{ "Date To : " + dateRange?.[1] }}</span>
+
+    <!-- Scenario 3: Display ค.ศ., Output ค.ศ. -->
+    <div style="display: flex; flex-direction: column; border: 1px solid #ccc; padding: 1rem; border-radius: 8px;">
+      <label style="font-weight: bold; margin-bottom: 0.5rem;">Scenario 3: Display ค.ศ., Output ค.ศ.</label>
+      <code style="font-size: 0.8rem; margin-bottom: 0.5rem;">[isBudhistYear]="false" [outputBudhistYear]="false"</code>
+      <p-date-picker [isBudhistYear]="false" [outputBudhistYear]="false" [(ngModel)]="date3"></p-date-picker>
+      <span style="font-size: small; margin-top: 0.5rem;">Output: {{date3}}</span>
+      <span style="font-size: small; color: green;">Year: {{date3?.getFullYear()}}</span>
     </div>
+
+    <!-- Scenario 4: Range Selection with พ.ศ. Output -->
+    <div style="display: flex; flex-direction: column; border: 1px solid #ccc; padding: 1rem; border-radius: 8px;">
+      <label style="font-weight: bold; margin-bottom: 0.5rem;">Scenario 4: Range Selection with พ.ศ. Output</label>
+      <code style="font-size: 0.8rem; margin-bottom: 0.5rem;">[isBudhistYear]="true" [outputBudhistYear]="true" selectionMode="range"</code>
+      <p-date-picker [isBudhistYear]="true" [outputBudhistYear]="true" [(ngModel)]="dateRange" selectionMode="range"></p-date-picker>
+      <span style="font-size: small; margin-top: 0.5rem;">From: {{dateRange?.[0]?.getFullYear() || 'N/A'}}</span>
+      <span style="font-size: small;">To: {{dateRange?.[1]?.getFullYear() || 'N/A'}}</span>
+    </div>
+
   </div>
 </div>

--- a/projects/demo-app/src/app/app.component.ts
+++ b/projects/demo-app/src/app/app.component.ts
@@ -12,11 +12,15 @@ import { DatePickerModule } from 'primeng-buddhist-year-datepicker';
 export class AppComponent {
   title = 'demo-app';
 
-  date:any;
-  dateRange: any;
-  
+  // Scenario 1: Display พ.ศ., Output ค.ศ.
+  date1: Date | null = null;
 
-  logData(){
-    console.log(this.dateRange)
-  }
+  // Scenario 2: Display พ.ศ., Output พ.ศ.
+  date2: Date | null = null;
+
+  // Scenario 3: Display ค.ศ., Output ค.ศ.
+  date3: Date | null = null;
+
+  // Scenario 4: Range with พ.ศ. output
+  dateRange: Date[] | null = null;
 }

--- a/projects/primeng-buddhist-datepicker/README.md
+++ b/projects/primeng-buddhist-datepicker/README.md
@@ -11,7 +11,7 @@ This library extends the [PrimeNG Datepicker](https://primeng.org/datepicker) to
 
 | Angular Version        | Library Version                       | Install Command                                  |
 | ---------------------- | ------------------------------------- | ------------------------------------------------ |
-| `^21.0.0`              | `primeng-buddhist-year-datepicker@21` | `npm i primeng-buddhist-year-datepicker` |
+| `^21.0.0`              | `primeng-buddhist-year-datepicker@21` | `npm i primeng-buddhist-year-datepicker`         |
 | `^20.0.0`              | `primeng-buddhist-year-datepicker@20` | `npm i primeng-buddhist-year-datepicker@^20.0.0` |
 | `^19.0.0`              | `primeng-buddhist-year-datepicker@19` | `npm i primeng-buddhist-year-datepicker@^19.0.0` |
 | `^17.0.0` to `<19.0.0` | `primeng-buddhist-year-datepicker@17` | `npm i primeng-buddhist-year-datepicker@^17.0.0` |
@@ -26,6 +26,9 @@ To see the component in action:
 
 ```bash
 npm install
+
+ng build primeng-buddhist-datepicker
+
 ng serve
 ```
 
@@ -47,9 +50,11 @@ selector datepicker the same as primeng add only [isBudhistYear] = true or false
   template: `
     <p-date-picker
       [isBudhistYear]="true"
+      [inputBudhistYear]="false"
+      [outputBudhistYear]="true"
       dateFormat="dd/mm/yy"
       placeholder="Select a date"
-    ></<p-date-picker>
+    ></p-date-picker>
   `
 })
 export class YourComponent {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,9 @@
     "paths": {
       "primeng-buddhist-datepicker": [
         "./dist/primeng-buddhist-datepicker"
+      ],
+      "primeng-buddhist-year-datepicker": [
+        "./dist/primeng-buddhist-datepicker"
       ]
     },
     "importHelpers": true,


### PR DESCRIPTION
## Changes
- **`inputBudhistYear`**: When `true`, assumes input values are in Buddhist Era (พ.ศ.) and converts to Gregorian internally
- **`outputBudhistYear`**: When `true`, outputs dates in Buddhist Era (พ.ศ.) format (+543 years)
- Fixed Buddhist year display in popup calendar header and year picker view
- Updated README with new properties documentation

## Usage
```html
<p-date-picker
  [isBudhistYear]="true"
  [inputBudhistYear]="false"
  [outputBudhistYear]="true"
  [(ngModel)]="date"
></p-date-picker>

Check out the demo app.